### PR TITLE
[POC] Alterar geração de PDF para padrão em português para uso da Beep

### DIFF
--- a/application/frontend/src/app/core/effects/download.effects.ts
+++ b/application/frontend/src/app/core/effects/download.effects.ts
@@ -283,7 +283,8 @@ export class DownloadEffects {
   }
 
   localizedDateString(dateVal, locale = "pt-Br", timezone = "America/Sao_Paulo") {
-    return new Date(dateVal).toLocaleString(locale, {timeZone: timezone});
+    const dateObj = new Date(dateVal);
+    return dateObj.toLocaleString(locale, {timeZone: timezone});
   }
 
   parseVisitData(

--- a/application/frontend/src/app/core/effects/download.effects.ts
+++ b/application/frontend/src/app/core/effects/download.effects.ts
@@ -209,9 +209,7 @@ export class DownloadEffects {
           vehicleOperatorIndices: vehicleOperatorIndices,
           vehicleOperatorLabels: vehicleOperatorLabels,
           visitType: 'Start of day',
-          visitEnd: new Date(
-            durationSeconds(route.vehicleStartTime).toNumber() * 1000
-          ).toUTCString(),
+          visitEnd: this.localizedDateString(durationSeconds(route.vehicleStartTime).toNumber() * 1000),
           timeToNextStop: formattedDurationSeconds(
             durationSeconds(route.visits[0]?.startTime || route.vehicleEndTime)
               .subtract(durationSeconds(route.vehicleStartTime))
@@ -242,9 +240,7 @@ export class DownloadEffects {
           vehicleIndex: route.vehicleIndex || 0,
           vehicleLabel: vehicle.label,
           visitType: 'End of day',
-          visitStart: new Date(
-            durationSeconds(route.vehicleEndTime).toNumber() * 1000
-          ).toUTCString(),
+          visitStart: this.localizedDateString(durationSeconds(route.vehicleEndTime).toNumber() * 1000),
         });
       }
     });
@@ -286,6 +282,10 @@ export class DownloadEffects {
     };
   }
 
+  localizedDateString(dateVal, locale = "pt-Br", timezone = "America/Sao_Paulo") {
+    return new Date(dateVal).toLocaleString(locale, {timeZone: timezone});
+  }
+
   parseVisitData(
     vehicle: IVehicle,
     shipments: IShipment[],
@@ -317,8 +317,8 @@ export class DownloadEffects {
       );
     }
 
-    const visitStart = new Date(1000 * startSeconds.toNumber()).toUTCString();
-    const visitEnd = new Date(1000 * endSeconds.toNumber()).toUTCString();
+    const visitStart = this.localizedDateString(1000 * startSeconds.toNumber());
+    const visitEnd = this.localizedDateString(1000 * endSeconds.toNumber())
 
     return {
       visitStart,

--- a/application/frontend/src/app/core/models/csv.ts
+++ b/application/frontend/src/app/core/models/csv.ts
@@ -99,6 +99,14 @@ export interface CsvData {
   location: string;
 }
 
+// SETUP COLUMN:LABEL
+export const CSV_COLUMNS_FOR_PDF = {
+  'Ship label': 'Agendamento',
+  'Visit start': 'Horário de chegada',
+  'Visit end': 'Horário de termino',
+  'Time to next stop': 'Tempo até o proximo',
+}
+
 export const CSV_COLUMN_ORDER = [
   'vehicleIndex',
   'vehicleLabel',


### PR DESCRIPTION
## Objetivo
Alterar geração do PDF do CFR para um padrão especifico para uso da Beep.

Antes:
![image](https://github.com/beep-saude/google-cloud-fleet-routing-app/assets/10059323/95a094ed-12ee-4a94-8d4c-4c048601f110)

Depois:
![image](https://github.com/beep-saude/google-cloud-fleet-routing-app/assets/10059323/2b2266ad-b2ed-49ff-90f2-3604d0e1a9b8)


## Migrações
NÃO

## Módulos e contextos impactados na aplicação
Lista dos componentes que foram impactados:
- effects/download.effect.ts
- containers/download-pdf-dialog
- models/csv
